### PR TITLE
change bosh_index to bosh_job_id

### DIFF
--- a/collectors/container_metrics_collector.go
+++ b/collectors/container_metrics_collector.go
@@ -25,35 +25,35 @@ func NewContainerMetricsCollector(
 	cpuPercentageMetricDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, container_metrics_subsystem, "cpu_percentage"),
 		"Cloud Foundry Firehose container metric: CPU used, on a scale of 0 to 100.",
-		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_index", "bosh_ip", "application_id", "instance_id"},
+		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_job_id", "bosh_ip", "application_id", "instance_id"},
 		nil,
 	)
 
 	memoryBytesMetricDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, container_metrics_subsystem, "memory_bytes"),
 		"Cloud Foundry Firehose container metric: bytes of memory used.",
-		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_index", "bosh_ip", "application_id", "instance_id"},
+		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_job_id", "bosh_ip", "application_id", "instance_id"},
 		nil,
 	)
 
 	diskBytesMetricDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, container_metrics_subsystem, "disk_bytes"),
 		"Cloud Foundry Firehose container metric: bytes of disk used.",
-		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_index", "bosh_ip", "application_id", "instance_id"},
+		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_job_id", "bosh_ip", "application_id", "instance_id"},
 		nil,
 	)
 
 	memoryBytesQuotaMetricDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, container_metrics_subsystem, "memory_bytes_quota"),
 		"Cloud Foundry Firehose container metric: maximum bytes of memory allocated to container.",
-		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_index", "bosh_ip", "application_id", "instance_id"},
+		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_job_id", "bosh_ip", "application_id", "instance_id"},
 		nil,
 	)
 
 	diskBytesQuotaMetricDesc := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, container_metrics_subsystem, "disk_bytes_quota"),
 		"Cloud Foundry Firehose container metric: maximum bytes of disk allocated to container.",
-		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_index", "bosh_ip", "application_id", "instance_id"},
+		[]string{"origin", "bosh_deployment", "bosh_job", "bosh_job_id", "bosh_ip", "application_id", "instance_id"},
 		nil,
 	)
 

--- a/collectors/counter_events_collector.go
+++ b/collectors/counter_events_collector.go
@@ -40,7 +40,7 @@ func (c CounterEventsCollector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.NewDesc(
 				prometheus.BuildFQName(c.namespace, counter_events_subsystem, metricName),
 				fmt.Sprintf("Cloud Foundry Firehose '%s' total counter event from '%s'.", counterEvent.Name, counterEvent.Origin),
-				[]string{"origin", "bosh_deployment", "bosh_job", "bosh_index", "bosh_ip"},
+				[]string{"origin", "bosh_deployment", "bosh_job", "bosh_job_id", "bosh_ip"},
 				nil,
 			),
 			prometheus.CounterValue,
@@ -57,7 +57,7 @@ func (c CounterEventsCollector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.NewDesc(
 				prometheus.BuildFQName(c.namespace, counter_events_subsystem, metricName),
 				fmt.Sprintf("Cloud Foundry Firehose '%s' delta counter event from '%s'.", counterEvent.Name, counterEvent.Origin),
-				[]string{"origin", "bosh_deployment", "bosh_job", "bosh_index", "bosh_ip"},
+				[]string{"origin", "bosh_deployment", "bosh_job", "bosh_job_id", "bosh_ip"},
 				nil,
 			),
 			prometheus.GaugeValue,

--- a/collectors/value_metrics_collector.go
+++ b/collectors/value_metrics_collector.go
@@ -40,7 +40,7 @@ func (c ValueMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.NewDesc(
 				prometheus.BuildFQName(c.namespace, value_metrics_subsystem, metricName),
 				fmt.Sprintf("Cloud Foundry Firehose '%s' value metric from '%s'.", valueMetric.Name, valueMetric.Origin),
-				[]string{"origin", "bosh_deployment", "bosh_job", "bosh_index", "bosh_ip", "unit"},
+				[]string{"origin", "bosh_deployment", "bosh_job", "bosh_job_id", "bosh_ip", "unit"},
 				nil,
 			),
 			prometheus.GaugeValue,


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry-community/firehose_exporter/issues/7.
Warning: unfortunately this change creates new time series because the labels change. Therefore historical measurements are lost.