### PR TITLE
Subscribe only to metrics feed from firehose

### DIFF
--- a/firehosenozzle/firehose_nozzle.go
+++ b/firehosenozzle/firehose_nozzle.go
@@ -82,7 +82,7 @@ func (n *FirehoseNozzle) consumeFirehose() {
 	if n.maxRetryCount > 0 {
 		n.consumer.SetMaxRetryCount(n.maxRetryCount)
 	}
-	n.messages, n.errs = n.consumer.Firehose(n.subscriptionID, "")
+	n.messages, n.errs = n.consumer.FilteredFirehose(n.subscriptionID, "", consumer.Metrics)
 }
 
 func (n *FirehoseNozzle) parseEnvelopes() error {


### PR DESCRIPTION
At the moment the `Firehose` function from the NOAA consumer is used. When instead using `FilteredFirehose` and restricting to only get the metrics we can avoid `LogMessage` events being sent at all. This leads even on an environment without many application to a meaningful reduction of
1. network bandwidth and 
1. cpu utilization.

+cc @mkuratczyk please feel free to add your comments. And thanks a lot for doing **all** the testing.